### PR TITLE
[PR] Fixed firefox to fallback to backdrop blur

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -177,7 +177,12 @@ const GlassContainer = forwardRef<
     const filterId = useId()
     const [shaderMapUrl, setShaderMapUrl] = useState<string>("")
 
-    const isFirefox = navigator.userAgent.toLowerCase().includes("firefox")
+    const [isFirefox, setIsFirefox] = useState(false)
+
+    useEffect(() => {
+      const navigatorIsFirefox = navigator.userAgent.toLowerCase().includes("firefox")
+      setIsFirefox(navigatorIsFirefox)
+    }, [])
 
     // Generate shader displacement map when in shader mode
     useEffect(() => {


### PR DESCRIPTION
This pull request fixes the Firefox and Safari showing fallback blur effect correctly.

This error was caused by hydration error, with combination of applying SSR to client (which has different `navigator.userAgent` string)